### PR TITLE
Add authentication headers to enroot import command if gitlab is used as docker registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The following variables control some aspects of the script functionality. They c
 
 These variables are not SLURM specific and can be used in the default `ENROOT` only mode.
 
-+ `CI_JOB_IMAGE` (YAML script `image:` option): a standard docker image for enroot to instantiate a container from;
++ `CI_JOB_IMAGE` (YAML script `image:` option): a standard docker image for enroot to instantiate a container from; If it hosted on gitlab (`CI_REGISTRY`), it will will be accessed via default token `CI_REGISTRY_PASSWORD`
 + `CI_WS`: a directory with shared data access across all nodes to be used as a workspace.
 
 Optional:

--- a/prepare.sh
+++ b/prepare.sh
@@ -37,7 +37,11 @@ if ! [[ $(enroot list | grep "${CONTAINER_NAME}") ]]; then
     # Import a container image from a specific location to enroot image dir
     # Scheme: docker://[USER@][REGISTRY#]IMAGE[:TAG]
     IMAGE_DIR="${ENROOT_DATA_PATH}"
-    URL="docker://${CUSTOM_ENV_CI_JOB_IMAGE}"
+    if [[ ${CUSTOM_ENV_CI_JOB_IMAGE} == "${CI_REGISTRY}"* ]]; then
+        URL="docker://${CUSTOM_ENV_CI_REGISTRY_USER}:${CUSTOM_ENV_CI_REGISTRY_PASSWORD}@${CUSTOM_ENV_CI_REGISTRY}#${CUSTOM_ENV_CI_JOB_IMAGE#*$CUSTOM_ENV_CI_REGISTRY/}"
+    else
+        URL="docker://${CUSTOM_ENV_CI_JOB_IMAGE}"
+    fi
     IMAGE_NAME="${CUSTOM_ENV_CI_JOB_IMAGE//[:@#.\/]/-}"
     # Utility timestamp and lock files
     IMAGE_TIMESTAMP_FILE=${IMAGE_DIR}/TIMESTAMP_${IMAGE_NAME}

--- a/prepare.sh
+++ b/prepare.sh
@@ -37,7 +37,7 @@ if ! [[ $(enroot list | grep "${CONTAINER_NAME}") ]]; then
     # Import a container image from a specific location to enroot image dir
     # Scheme: docker://[USER@][REGISTRY#]IMAGE[:TAG]
     IMAGE_DIR="${ENROOT_DATA_PATH}"
-    if [[ ${CUSTOM_ENV_CI_JOB_IMAGE} == "${CI_REGISTRY}"* ]]; then
+    if [[ ${CUSTOM_ENV_CI_JOB_IMAGE} == "${CUSTOM_ENV_CI_REGISTRY}"* ]]; then
         URL="docker://${CUSTOM_ENV_CI_REGISTRY_USER}:${CUSTOM_ENV_CI_REGISTRY_PASSWORD}@${CUSTOM_ENV_CI_REGISTRY}#${CUSTOM_ENV_CI_JOB_IMAGE#*$CUSTOM_ENV_CI_REGISTRY/}"
     else
         URL="docker://${CUSTOM_ENV_CI_JOB_IMAGE}"


### PR DESCRIPTION
Fix issue #9: Add authentication headers to enroot import command if gitlab is used as docker registry